### PR TITLE
Reg/unreg Windows path feature implementation and some fixes

### DIFF
--- a/src/twig/Archiver/Archiver.cs
+++ b/src/twig/Archiver/Archiver.cs
@@ -83,7 +83,7 @@
             var compressedBytes = compressor.Wrap(data);
             if (File.Exists($"{path}.zs") && !overwrite)
             {
-                AnsiConsole.WriteLine($"A compressed file with the same name {Path.GetFileNameWithoutExtension(path)} already exists. Use the -o | --overwrite parameter to force overwrite.");
+                AnsiConsole.WriteLine($"A compressed file with the same name {Path.GetFileNameWithoutExtension(path)} already exists. Use the -f | --force parameter to force overwrite.");
                 return;
             }
             var writer = await FileHelper.WriteFileAsync(compressedBytes, path, output, ".zs");
@@ -154,7 +154,7 @@
             var decompressedBytes = decompressor.Unwrap(compressedData);
             var unpackingPath = Path.ChangeExtension(path, "");
 
-            if (File.Exists($"{path}") && !overwrite)
+            if (File.Exists($"{unpackingPath}") && !overwrite)
             {
                 AnsiConsole.WriteLine($"A decompressed file with the same name {Path.GetFileNameWithoutExtension(path)} already exists. Use the -o | --overwrite parameter to force overwrite.");
                 return;

--- a/src/twig/Commands/DefaultCommand.cs
+++ b/src/twig/Commands/DefaultCommand.cs
@@ -55,6 +55,14 @@
             [Description("Find the best compression level given a file and duration\nExample: twig filepath --advise 2000\nDuration is in milliseconds.")]
             public int AdviseDuration { get; set; }
 
+            [CommandOption("--register")]
+            [Description("Register twig into the Windows Path.")]
+            public bool Register { get; set; }
+
+            [CommandOption("--unregister")]
+            [Description("Unregister twig from the Windows Path.")]
+            public bool Unregister { get; set; }
+
             public override ValidationResult Validate()
             {
                 if (File.GetAttributes(Path).HasFlag(FileAttributes.Directory) && System.IO.Path.HasExtension(OutputPath))

--- a/src/twig/Helpers/ArgsHelper.cs
+++ b/src/twig/Helpers/ArgsHelper.cs
@@ -8,6 +8,23 @@
         public static string[] HandleArgs(string[] args, int defaultVal)
         {
             var argsList = args.ToList();
+
+            if (argsList.Contains("--register"))
+            {
+                FileAssociationHelper.RegisterForFileExtension(".zs");
+                FileAssociationHelper.AddContextMenuOption("SOFTWARE\\Classes\\*\\shell\\twig", "Process with twig");
+                FileAssociationHelper.AddContextMenuOption("SOFTWARE\\Classes\\Directory\\shell\\twig", "Process folder with twig");
+                Console.WriteLine("Application has been registered.");
+            }
+
+            if (argsList.Contains("--unregister"))
+            {
+                FileAssociationHelper.UnregisterForFileExtension(".zs");
+                FileAssociationHelper.RemoveContextMenuOption("SOFTWARE\\Classes\\*\\shell\\twig");
+                FileAssociationHelper.RemoveContextMenuOption("SOFTWARE\\Classes\\Directory\\shell\\twig");
+                Console.WriteLine("Application has been unregistered.");
+            }
+
             if (!argsList.Contains("--advise"))
             {
                 return args;

--- a/src/twig/Helpers/FileAssociationHelper.cs
+++ b/src/twig/Helpers/FileAssociationHelper.cs
@@ -1,0 +1,59 @@
+﻿namespace twig
+{
+    using System;
+    using System.Dynamic;
+    using System.Reflection;
+    using System.Runtime.InteropServices;
+    using Microsoft.Win32;
+    using Spectre.Console;
+
+    public static class FileAssociationHelper
+    {
+        public static void AddContextMenuOption(string subKey, string value)
+        {
+            var appPath = System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName;
+            var key = Registry.CurrentUser.CreateSubKey(subKey, true);
+            key.SetValue("", value);
+            var newSubKey = key.CreateSubKey("command");
+            newSubKey.SetValue("", appPath + " %1");
+            newSubKey.Close();
+            key.Close();
+
+            SHChangeNotify(0x08000000, 0x0000, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        public static void RegisterForFileExtension(string extension)
+        {
+            var appPath = System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName;
+            var key = Registry.CurrentUser.CreateSubKey("Software\\Classes\\" + extension);
+            var subKey = key.CreateSubKey("shell\\open\\command");
+            subKey.SetValue("", appPath + " %1");
+            subKey.Close();
+            key.Close();
+
+            SHChangeNotify(0x08000000, 0x0000, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        public static void RemoveContextMenuOption(string subKey)
+        {
+            var key = Registry.CurrentUser.OpenSubKey(subKey, true);
+            key.DeleteValue("");
+            key.DeleteSubKey("command");
+            key.Close();
+
+            SHChangeNotify(0x08000000, 0x0000, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        public static void UnregisterForFileExtension(string extension)
+        {
+            var key = Registry.CurrentUser.OpenSubKey("Software\\Classes\\" + extension, true);
+            key.DeleteSubKey("shell\\open\\command");
+            key.Close();
+
+            SHChangeNotify(0x08000000, 0x0000, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        [DllImport("shell32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern void SHChangeNotify(uint wEventId, uint uFlags, IntPtr dwItem1, IntPtr dwItem2);
+    }
+}


### PR DESCRIPTION
The path argument is required value. To make it possible to register the application without this and other arguments (only --register or --unregister command), args check for --register command going in the ArgsHelper.